### PR TITLE
Feat/pre commit lint

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -106,5 +106,11 @@
     ],
     "coverageDirectory": "../coverage",
     "testEnvironment": "node"
+  },
+  "lint-staged":{
+    "**/*.{js,jsx,ts,tsx}":[
+      "npx prettier --write",
+      "npx eslint --fix"
+    ]
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -21,9 +21,7 @@ export class UserService {
 
   getUserByEmail(email: string): Promise<User | null> {
     return this.prismaService.user.findUnique({
-      where: {
-        email,
-      },
+      where: { email },
     });
   }
 


### PR DESCRIPTION
Fix for Pre-commit linting. ESLint and Prettier both get run just before a commit, to prevent committing linting errors.